### PR TITLE
Fix `maybe-utils` dependency version

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
 name = "semver"
-version = "0.1.4"
+version = "0.1.5"
 [dependencies]
 maybe-utils = "StanzaOrg/maybe-utils|0.1.4"

--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
 name = "semver"
 version = "0.1.4"
 [dependencies]
-maybe-utils = "StanzaOrg/maybe-utils|0.1.3"
+maybe-utils = "StanzaOrg/maybe-utils|0.1.4"


### PR DESCRIPTION
This package is still referencing the older version of `maybe-utils` that was broken with the introduction of `PeekSeq`. 

This fixes that bug.