### PR TITLE
Add Hashable Interface and Fix Build

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,4 @@
 name = "semver"
-version = "0.1.5"
+version = "0.1.6"
 [dependencies]
 maybe-utils = "StanzaOrg/maybe-utils|0.1.4"

--- a/src/lib.stanza
+++ b/src/lib.stanza
@@ -2,10 +2,13 @@ defpackage semver:
   import core
   import maybe-utils
 
-public defstruct SemanticVersion <: Printable & Equalable & Comparable<SemanticVersion>:
+public defstruct SemanticVersion <: Printable & Equalable & Hashable & Comparable<SemanticVersion>:
   major: Int
   minor: Int
   patch: Int
+with:
+  hashable => true
+  equalable => true
 
 defn to-int? (s: String) -> Maybe<Int>:
   if s == "":
@@ -28,11 +31,6 @@ public defn parse-semver (s: String) -> Maybe<SemanticVersion>:
 
 defmethod print (o: OutputStream, v: SemanticVersion) -> False:
   print(o, "%~.%~.%~" % [major(v), minor(v), patch(v)])
-
-defmethod equal? (v1: SemanticVersion, v2: SemanticVersion) -> True|False:
-  major(v1) == major(v2) and
-  minor(v1) == minor(v2) and
-  patch(v1) == patch(v2)
 
 defmethod compare (v1: SemanticVersion, v2: SemanticVersion) -> Int:
   label<Int> return:

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,3 +1,4 @@
+include? ".slm/stanza.proj"
 include "src/stanza.proj"
 include "tests/stanza.proj"
 

--- a/tests/main.stanza
+++ b/tests/main.stanza
@@ -1,6 +1,7 @@
 #use-added-syntax(tests)
 defpackage semver/tests:
   import core
+  import collections
   import semver
 
 deftest empty-string-should-not-parse:
@@ -84,3 +85,16 @@ deftest different-version-should-not-be-equal:
 
 deftest should-print-separated-by-dots:
   #EXPECT(to-string(SemanticVersion(1, 2, 3)) == "1.2.3")
+
+deftest is-hashable:
+  val table = to-hashtable<SemanticVersion, String>([
+    SemanticVersion(0, 1, 2) => "hash1",
+    SemanticVersion(0, 2, 2) => "hash2",
+    SemanticVersion(1, 0, 3) => "hash3"
+  ])
+
+  val hash-str = get?(table, SemanticVersion(0, 1, 2), false)
+  #EXPECT(hash-str is String)
+
+  val non-hash-str = get?(table, SemanticVersion(2,3,2), false)
+  #EXPECT(non-hash-str is False)


### PR DESCRIPTION
Updated `SemanticVersion` to provide the `Hashable` interface.
Fixed bugs in the build so that we can now build the tests with the latest `slm`.
